### PR TITLE
Download endpoint option

### DIFF
--- a/includes/admin/meta-boxes.php
+++ b/includes/admin/meta-boxes.php
@@ -201,7 +201,7 @@ function dedo_meta_box_download( $post ) {
 							<label for="open_browser_true"><input name="open_browser" id="open_browser_true" type="radio" value="1" <?php echo ( 1 === $open_browser ) ? 'checked' : ''; ?> /> <?php _e( 'Yes', 'delightful-downloads' ); ?></label>
 							<label for="open_browser_false"><input name="open_browser" id="open_browser_false" type="radio" value="0" <?php echo ( 0 === $open_browser ) ? 'checked' : ''; ?> /> <?php _e( 'No', 'delightful-downloads' ); ?></label>
 							<label for="open_browser_inherit"><input name="open_browser" id="open_browser_inherit" type="radio" value <?php echo ( '' === $open_browser ) ? 'checked' : ''; ?> /> <?php _e( 'Inherit', 'delightful-downloads' ); ?></label>
-							<p class="description"><?php echo sprintf( __( 'This file will attempt to open in the browser window. If the file is located within the Delightful Downloads upload directory, you will need to set the %sfolder protection%s setting to \'No\'.', 'delightful-downloads' ), '<a href="' . admin_url( 'edit.php?post_type=dedo_download&page=dedo_settings&tab=advanced' ) . '" target="_blank">', '</a>' ); ?></p>
+							<p class="description"><?php echo sprintf( __( 'This file will attempt to open in the browser window.', 'delightful-downloads' ), '<a href="' . admin_url( 'edit.php?post_type=dedo_download&page=dedo_settings&tab=advanced' ) . '" target="_blank">', '</a>' ); ?></p>
 						</td>
 					</tr>
 				</tbody>

--- a/includes/admin/page-settings.php
+++ b/includes/admin/page-settings.php
@@ -523,6 +523,22 @@ function dedo_settings_download_url_field() {
 }
 
 /**
+ * Download Endpoint field
+ *
+ * @since  1.5
+ */
+function dedo_settings_download_endpoint_field() {
+	global $dedo_options;
+	$checked = absint( $dedo_options['download_endpoint'] );
+	?>
+
+	<label for="download_endpoint_switch_true"><input name="delightful-downloads[download_endpoint]" id="download_endpoint_switch_true" type="radio" value="1" <?php echo ( 1 === $checked ) ? 'checked' : ''; ?> /> <?php _e( 'Yes', 'delightful-downloads' ); ?></label>
+	<label for="download_endpoint_switch_false"><input name="delightful-downloads[download_endpoint]" id="download_endpoint_switch_false" type="radio" value="0" <?php echo ( 0 === $checked ) ? 'checked' : ''; ?> /> <?php _e( 'No', 'delightful-downloads' ); ?></label>
+	<p class="description"><?php echo __( 'Process downloads through a URL endpoint instead of a query parameter.', 'delightful-downloads' ) . ' <code>' . dedo_download_link( 123, true ) . '</code>'; ?></p>
+	<?php
+}
+
+/**
  * Render Folder Protection field
  *
  * @since  1.5

--- a/includes/admin/page-settings.php
+++ b/includes/admin/page-settings.php
@@ -519,7 +519,7 @@ function dedo_settings_download_url_field() {
 	$text = $dedo_options['download_url'];
 
 	echo '<input type="text" name="delightful-downloads[download_url]" value="' . esc_attr( $text ) . '" class="regular-text" />';
-	echo '<p class="description">' . __( 'The URL for download links.', 'delightful-downloads' ) . ' <code>' . dedo_download_link( 123 ) . '</code></p>';
+	echo '<p class="description">' . __( 'The URL for download links.', 'delightful-downloads' ) . ' <code>' . dedo_download_link( 123, 'query' ) . '</code></p>';
 }
 
 /**
@@ -534,7 +534,7 @@ function dedo_settings_download_endpoint_field() {
 
 	<label for="download_endpoint_switch_true"><input name="delightful-downloads[download_endpoint]" id="download_endpoint_switch_true" type="radio" value="1" <?php echo ( 1 === $checked ) ? 'checked' : ''; ?> /> <?php _e( 'Yes', 'delightful-downloads' ); ?></label>
 	<label for="download_endpoint_switch_false"><input name="delightful-downloads[download_endpoint]" id="download_endpoint_switch_false" type="radio" value="0" <?php echo ( 0 === $checked ) ? 'checked' : ''; ?> /> <?php _e( 'No', 'delightful-downloads' ); ?></label>
-	<p class="description"><?php echo __( 'Process downloads through a URL endpoint instead of a query parameter.', 'delightful-downloads' ) . ' <code>' . dedo_download_link( 123, true ) . '</code>'; ?></p>
+	<p class="description"><?php echo __( 'Process downloads through a URL endpoint instead of a query parameter.', 'delightful-downloads' ) . ' <code>' . dedo_download_link( 123, 'endpoint' ) . '</code>'; ?></p>
 	<?php
 }
 

--- a/includes/admin/page-settings.php
+++ b/includes/admin/page-settings.php
@@ -317,7 +317,7 @@ function dedo_settings_open_browser_field() {
 
 	<label for="open_browser_true"><input name="delightful-downloads[open_browser]" id="open_browser_true" type="radio" value="1" <?php echo ( 1 === $checked ) ? 'checked' : ''; ?> /> <?php _e( 'Yes', 'delightful-downloads' ); ?></label>
 	<label for="open_browser_false"><input name="delightful-downloads[open_browser]" id="open_browser_false" type="radio" value="0" <?php echo ( 0 === $checked ) ? 'checked' : ''; ?> /> <?php _e( 'No', 'delightful-downloads' ); ?></label>
-	<p class="description"><?php _e( 'Attempt to open files in the browser window. This can be overridden on a per-download basis. For files located within the Delightful Downloads upload directory, set folder protection to \'No\', which can be found under the advanced tab.', 'delightful-downloads' ); ?></p>
+	<p class="description"><?php _e( 'Attempt to open files in the browser window. This can be overridden on a per-download basis.', 'delightful-downloads' ); ?></p>
 	<?php
 }
 

--- a/includes/admin/page-settings.php
+++ b/includes/admin/page-settings.php
@@ -31,6 +31,11 @@ function dedo_register_settings() {
 	$registered_tabs = dedo_get_tabs();
 	$registered_settings = dedo_get_options();
 
+	// Deferred flushing if the endpoint setting was changed and the flag is set
+	if (delete_transient('deedo_flush_rewrite_rules') ) { 
+		flush_rewrite_rules();
+	}
+
 	// Register whitelist
 	register_setting( 'dedo_settings', 'delightful-downloads', 'dedo_validate_settings' ); 
 
@@ -590,6 +595,13 @@ function dedo_validate_settings( $input ) {
 	 
 	// Ensure download URL does not contain illegal characters
 	$input['download_url'] = strtolower( preg_replace( '/[^A-Za-z0-9_-]/', '', $input['download_url'] ) );
+
+	// Flush rewrite rules if the endpoint setting has changed
+	if ( $input['download_endpoint'] != $dedo_options['download_endpoint'] ) {
+		// Flushing is deferred to the next render cycle by a transient flag as flushing directly does not work: http://wordpress.stackexchange.com/questions/47747
+		// The transient's name cannot start with 'dedo', else it gets cleared by dedo_delete_all_transients
+		set_transient('deedo_flush_rewrite_rules', 'dummy', YEAR_IN_SECONDS);
+	}
 
 	// Run folder protection if option changed
 	if ( $input['folder_protection'] != $dedo_options['folder_protection'] ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -179,8 +179,18 @@ function dedo_get_shortcode_lists() {
  *
  * @since  1.0
  */
-function dedo_download_link( $id, $endpoint = false ) {
+function dedo_download_link( $id, $type = 'auto' ) {
 	 global $dedo_options;
+
+	 if ( $type === 'query' ) {
+	 	$endpoint = false;
+	 }
+	 else if ( $type === 'endpoint' ) {
+	 	$endpoint = true;
+	 }
+	 else { // $type === 'auto'
+	 	$endpoint = $dedo_options['download_endpoint'] == 1;
+	 }
 	 
 	 $output = esc_html( home_url( ( $endpoint ? '/' : '?' ) . $dedo_options['download_url'] . ( $endpoint ? '/' : '=' ) . $id ) );
 	 return apply_filters( 'dedo_download_link', $output );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -179,10 +179,10 @@ function dedo_get_shortcode_lists() {
  *
  * @since  1.0
  */
-function dedo_download_link( $id ) {
+function dedo_download_link( $id, $endpoint = false ) {
 	 global $dedo_options;
 	 
-	 $output = esc_html( home_url( '?' . $dedo_options['download_url'] . '=' . $id ) );
+	 $output = esc_html( home_url( ( $endpoint ? '/' : '?' ) . $dedo_options['download_url'] . ( $endpoint ? '/' : '=' ) . $id ) );
 	 return apply_filters( 'dedo_download_link', $output );
 }
 

--- a/includes/options.php
+++ b/includes/options.php
@@ -130,6 +130,12 @@ function dedo_get_options() {
 			'type'		=> 'text',
 			'default'	=> 'ddownload',
 		),
+		'download_endpoint'	=> array(
+			'name'		=> __( 'Download Endpoint', 'delightful-downloads' ),
+			'tab'		=> 'advanced',
+			'type'		=> 'radio',
+			'default'	=> 0
+		),
 		'folder_protection'	=> array(
 			'name'		=> __( 'Folder Protection', 'delightful-downloads' ),
 			'tab'		=> 'advanced',

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -131,7 +131,6 @@ function dedo_download_process() {
 
 			// Set headers
 			nocache_headers();
-			header( "X-Robots-Tag: noindex, nofollow", true );
 			header( "Content-Type: " . dedo_download_mime( $download_path ) );
 			header( "Content-Description: File Transfer" );
 			header( "Content-Disposition: attachment; filename=\"" . basename( $download_path ) . "\";" );

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -20,12 +20,13 @@ if ( !defined( 'ABSPATH' ) ) exit;
  */
 function dedo_download_process() {
 	global $dedo_options;
+	global $wp;
 	
 	// Get download id
-	if ( isset( $_GET[$dedo_options['download_url']] ) ) {
+	if ( isset( $wp->query_vars[$dedo_options['download_url']] ) ) {
 		
 		// Ensure only positive int, else could be fishy!
-		$download_id = absint( $_GET[$dedo_options['download_url']] );
+		$download_id = absint( $wp->query_vars[$dedo_options['download_url']] );
 
 		// Check valid download
 		if ( !dedo_download_valid( $download_id ) ) {
@@ -165,4 +166,39 @@ function dedo_download_process() {
 	}
 
 }
-add_action( 'init', 'dedo_download_process', 0 );
+
+/**
+ * Add query variable
+ *
+ * This is done automatically by add_rewrite_endpoint if the endpoint option
+ * is used, but for the query option it needs to be set to be available in
+ * $wp->query_vars in the download processing handler.
+ *
+ * @since 1.5
+ */
+function dedo_download_add_query_vars( $vars ) {
+	global $dedo_options;
+
+	$vars[] = $dedo_options['download_url'];
+
+	return $vars;
+}
+
+/**
+ * Register Download Endpoint
+ *
+ * @since 1.5
+ */
+function dedo_download_add_endpoint() {
+	global $dedo_options;
+
+	// only add the endpoint if the option is activated in the settings
+	if( $dedo_options['download_endpoint'] == 1 ) {
+		add_rewrite_endpoint( $dedo_options['download_url'], EP_ROOT );
+	}
+}
+
+add_filter( 'query_vars', 'dedo_download_add_query_vars', 0 );
+add_action( 'init', 'dedo_download_add_endpoint', 0 );
+add_action( 'parse_request', 'dedo_download_process', 0 );
+

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -114,11 +114,6 @@ function dedo_download_process() {
 		// Open in browser
 		$open_browser = ( isset( $options['open_browser'] ) ) ? $options['open_browser'] : $dedo_options['open_browser'];
 
-		if ( $open_browser ) {
-			header( "Location: $download_url" );
-			exit();
-		}
-
 		// Convert to path
 		if ( $download_path = dedo_get_abs_path( $download_url ) ) {
 
@@ -133,7 +128,7 @@ function dedo_download_process() {
 			nocache_headers();
 			header( "Content-Type: " . dedo_download_mime( $download_path ) );
 			header( "Content-Description: File Transfer" );
-			header( "Content-Disposition: attachment; filename=\"" . basename( $download_path ) . "\";" );
+			header( "Content-Disposition: ".($open_browser ? "inline" : "attachment")."; filename=\"" . basename( $download_path ) . "\";" );
 			header( "Content-Transfer-Encoding: binary" );
 			header( "Content-Length: " . @filesize( $download_path ) ); // filesize causes blank downloads on Windows servers
 


### PR DESCRIPTION
I added an option for people who prefer to have download paths instead of a query parameter, e.g. `http://myblog.com/download/123` instead of `http://myblog.com/?download=123`. This can be toggled in the advanced settings, called 'Download Endpoint'.

It's just the last 3 commits which build upon my previous pull request #55.